### PR TITLE
Document `clock` in the interpreter options

### DIFF
--- a/docs/guides/interpretation.md
+++ b/docs/guides/interpretation.md
@@ -191,6 +191,7 @@ The following options can be passed into the interpreter as the 2nd argument (`i
   - If `false`, events sent to an uninitialized service will throw an error.
 - `devTools` (boolean) - Signifies whether events should be sent to the [Redux DevTools extension](https://github.com/zalmoxisus/redux-devtools-extension). Defaults to `false`.
 - `logger` - Specifies the logger to be used for `log(...)` actions. Defaults to the native `console.log` method.
+- `clock` - Specifies the [clock interface for delayed actions](./delays.md#interpretation). Defaults to the native `setTimeout` and `clearTimeout` functions.
 
 ## Custom Interpreters
 


### PR DESCRIPTION
👋  Noticed that `clock` was missing in https://xstate.js.org/docs/guides/interpretation.html#options